### PR TITLE
Non-exempt encryption for Apple

### DIFF
--- a/apps/app/app.config.ts
+++ b/apps/app/app.config.ts
@@ -21,7 +21,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
 	ios: {
 		supportsTablet: true,
 		bundleIdentifier: 'app.habiti.app',
-		associatedDomains: ['applinks:habiti.app']
+		associatedDomains: ['applinks:habiti.app'],
+		config: {
+			usesNonExemptEncryption: false
+		}
 	},
 	android: {
 		package: 'app.habiti.app',

--- a/apps/app/eas.json
+++ b/apps/app/eas.json
@@ -5,7 +5,10 @@
 	"build": {
 		"development": {
 			"developmentClient": true,
-			"distribution": "internal"
+			"distribution": "internal",
+			"ios": {
+				"image": "latest"
+			}
 		},
 		"simulator": {
 			"developmentClient": true,

--- a/apps/dashboard/app.json
+++ b/apps/dashboard/app.json
@@ -17,7 +17,10 @@
 		"assetBundlePatterns": ["**/*"],
 		"ios": {
 			"supportsTablet": true,
-			"bundleIdentifier": "app.habiti.dashboard"
+			"bundleIdentifier": "app.habiti.dashboard",
+			"config": {
+				"usesNonExemptEncryption": false
+			}
 		},
 		"android": {
 			"package": "app.habiti.dashboard",


### PR DESCRIPTION
This PR ensures that building for Apple does not result in an encryption warning.