### PR TITLE
Add product images to the orders screen [build-native]

### DIFF
--- a/apps/app/graphql/Order.graphql
+++ b/apps/app/graphql/Order.graphql
@@ -15,6 +15,10 @@ query UserOrders {
 				product {
 					id
 					name
+					images {
+						id
+						path
+					}
 				}
 				unitPrice
 				quantity

--- a/apps/app/src/components/orders/OrdersListItem.tsx
+++ b/apps/app/src/components/orders/OrdersListItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
-import { Avatar, Row, Typography } from '@habiti/components';
+import { View, StyleSheet, Image } from 'react-native';
+import { Avatar, Row, Spacer, Typography } from '@habiti/components';
 
 import { UserOrdersQuery } from '../../types/api';
 
@@ -12,13 +12,26 @@ interface OrdersListItemProps {
 const OrdersListItem: React.FC<OrdersListItemProps> = ({ order, onPress }) => {
 	return (
 		<Row onPress={onPress}>
-			<View style={styles.container}>
-				<Avatar
-					uri={order.store.image?.path}
-					fallbackText={order.store.name}
-					size={40}
-				/>
-				<Typography>{order.store.name}</Typography>
+			<View>
+				<View style={styles.container}>
+					<Avatar
+						uri={order.store.image?.path}
+						fallbackText={order.store.name}
+						size={40}
+					/>
+					<Typography>{order.store.name}</Typography>
+				</View>
+				<Spacer y={8} />
+				<View style={styles.products}>
+					{order.products.map(product => (
+						<View key={product.product.id}>
+							<Image
+								source={{ uri: product.product.images?.[0].path }}
+								style={styles.productImage}
+							/>
+						</View>
+					))}
+				</View>
 			</View>
 		</Row>
 	);
@@ -29,6 +42,15 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		alignItems: 'center',
 		gap: 8
+	},
+	products: {
+		flexDirection: 'row',
+		gap: 8
+	},
+	productImage: {
+		width: 48,
+		height: 48,
+		borderRadius: 6
 	}
 });
 

--- a/apps/app/src/types/api.tsx
+++ b/apps/app/src/types/api.tsx
@@ -1153,7 +1153,12 @@ export type UserOrdersQuery = {
 				__typename?: 'OrderProduct';
 				unitPrice: number;
 				quantity: number;
-				product: { __typename?: 'Product'; id: string; name: string };
+				product: {
+					__typename?: 'Product';
+					id: string;
+					name: string;
+					images: Array<{ __typename?: 'Image'; id: string; path: string }>;
+				};
 			}>;
 		}>;
 	};
@@ -1906,6 +1911,10 @@ export const UserOrdersDocument = gql`
 					product {
 						id
 						name
+						images {
+							id
+							path
+						}
 					}
 					unitPrice
 					quantity


### PR DESCRIPTION
- Force building for client-facing app
- Add product images to the orders screen (mostly for creating a diff that the build process will pick up)